### PR TITLE
Use the latest version of webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "through": ">=2.3.6 <2.4.0-0",
     "vinyl-fs": ">=0.3.9 <0.4.0-0",
     "vinyl-named": ">=1.1.0 <1.2.0-0",
-    "webpack": ">=1.4.0-beta6"
+    "webpack": ">=1.4.0-beta6 <1.6.0-0"
   },
   "peerDependencies": {
-    "webpack": ">=1.4.0-beta6"
+    "webpack": ">=1.4.0-beta6 <1.6.0-0"
   },
   "keywords": [
     "gulpplugin",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "memory-fs": ">=0.1.0 <0.2.0-0",
     "vinyl": ">=0.3.0 <0.4.0-0",
     "through": ">=2.3.4 <2.4.0-0",
-    "webpack": ">=1.4.0-beta6 <1.5.0-0",
     "gulp-util": ">=3.0.0 <3.1.0-0"
   },
   "devDependencies": {
@@ -32,7 +31,11 @@
     "tape": ">=3.0.0 <3.1.0-0",
     "through": ">=2.3.6 <2.4.0-0",
     "vinyl-fs": ">=0.3.9 <0.4.0-0",
-    "vinyl-named": ">=1.1.0 <1.2.0-0"
+    "vinyl-named": ">=1.1.0 <1.2.0-0",
+    "webpack": ">=1.4.0-beta6"
+  },
+  "peerDependencies": {
+    "webpack": ">=1.4.0-beta6"
   },
   "keywords": [
     "gulpplugin",


### PR DESCRIPTION
The latest version of ```webpack``` has some new features (support symLinks,etc...) but we can't use it due to restriction on version ```<1.5.0-0```

Is it possible to allow an upgrade by modifying ```package.json``` ?
After some tests I didn't see any issue between this version and gulp-webpack.

Maybe a better solution could be to set webpack in ```devDependencies``` and ```peerDependencies``` and remove it from ```dependencies``` to allow project to better manage wish version they want to use ?

Here is a pull request that explain this possibility