### PR TITLE
reset entry to [] after we don't need it

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ module.exports = function(options, wp, done) {
     options.entry           = options.entry           || entry;
     options.output.path     = options.output.path     || process.cwd();
     options.output.filename = options.output.filename || '[hash].js';
+    entry = [];
 
     if (!options.entry) {
       gutil.log('gulp-webpack - No files given; aborting compilation');


### PR DESCRIPTION
I'm trying to use gulp-webpack with wallaby, and I found that in some cases, entry = 'string', which doesn't have .push so it fails on line 73.