### PR TITLE
Expose original 'done' callback to the custom callback.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,34 +25,38 @@ var defaultStatsOptions = {
 
 module.exports = function(options, wp, done) {
   options = options || {};
-  if (typeof done !== 'function') {
-    var callingDone = false;
-    done = function(err, stats) {
-      stats = stats || {};
-      if (options.quiet || callingDone) {
-        return;
-      }
-      // Debounce output a little for when in watch mode
-      if (options.watch) {
-        callingDone = true;
-        setTimeout(function() { callingDone = false; }, 500);
-      }
-      if (options.verbose) {
-        gutil.log(stats.toString({
-          colors: gutil.colors.supportsColor,
-        }));
-      } else {
-        var statsOptions = options && options.stats || {};
 
-        Object.keys(defaultStatsOptions).forEach(function(key) {
-          if (typeof statsOptions[key] === 'undefined') {
-            statsOptions[key] = defaultStatsOptions[key];
-          }
-        });
-
-        gutil.log(stats.toString(statsOptions));
-      }
+  var callingDone = false;
+  var webpackDone = function(err, stats) {
+    stats = stats || {};
+    if (options.quiet || callingDone) {
+      return;
     }
+    // Debounce output a little for when in watch mode
+    if (options.watch) {
+      callingDone = true;
+      setTimeout(function() { callingDone = false; }, 500);
+    }
+    if (options.verbose) {
+      gutil.log(stats.toString({
+        colors: gutil.colors.supportsColor,
+      }));
+    } else {
+      var statsOptions = options && options.stats || {};
+
+      Object.keys(defaultStatsOptions).forEach(function(key) {
+        if (typeof statsOptions[key] === 'undefined') {
+          statsOptions[key] = defaultStatsOptions[key];
+        }
+      });
+
+      gutil.log(stats.toString(statsOptions));
+    }
+  };
+  if (typeof done === 'function') {
+    done = done.bind({ 'webpackDone': webpackDone });
+  } else {
+    done = webpackDone;
   }
 
   var webpack = wp || require('webpack');

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,9 @@ gulp.task('default', function() {
 });
 ```
 
-Pass in 3rd argument if you want to access the stats outputted from webpack when the compilation is done:
+Pass in 3rd argument if you want to access the stats outputted from webpack when the compilation is done.
+In addition, if you wish to delegate to the original done callback, you may do it via call to
+`this.webpackDone`:
 
 
 ```js
@@ -66,6 +68,9 @@ gulp.task('default', function() {
       /* config */
     }, null, function(err, stats) {
       /* Use stats to do more things if needed */
+
+      /* Call original callback if needed */
+      this.webpackDone(err, stats);
     }))
     .pipe(gulp.dest('dist/'));
 });


### PR DESCRIPTION
This can be done via this.webpackDone in the custom callback. Since original callback needs `options` and accesses `callingDone` in the parent context, in my opinion, it is better to be kept as instance method accessible via `this`.